### PR TITLE
Fix timing corner case to avoid panic()

### DIFF
--- a/close.go
+++ b/close.go
@@ -18,6 +18,12 @@ type graceful struct{}
 func (t graceful) shutdown(ctx context.Context, session *mgo.Session, closedChannel chan bool) {
 	session.Close()
 
+	defer func() {
+		if x := recover(); x != nil {
+			// do nothing ... just handle timing corner case and avoid "panic: send on closed channel"
+		}
+	}()
+
 	closedChannel <- true
 	return
 }

--- a/close_corner_case_problem/demo_channel_closed.go
+++ b/close_corner_case_problem/demo_channel_closed.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+	//	mgo "github.com/globalsign/mgo"
+)
+
+// Graceful represents an interface to the shutdown method
+type Graceful interface {
+	shutdown(ctx context.Context /*, session *mgo.Session,*/, closedChannel chan bool)
+}
+
+type graceful struct{}
+
+func (t graceful) shutdown(ctx context.Context /*session *mgo.Session,*/, closedChannel chan bool) {
+	//session.Close()
+
+	log.Printf("in shutdown()")
+	time.Sleep(time.Second) // simulate a session.Close() taking a while
+	log.Printf("shutdown: sending to closedChannel")
+
+	defer func() { // remove this defer and you will see a "panic: send on closed channel"
+		if x := recover(); x != nil {
+			log.Printf("recovered a panic: %v: ", x)
+			// do nothing ... just handle timing corner case and avoid "panic: send on closed channel"
+		}
+	}()
+
+	log.Printf("about to send 'true' over closedChannel")
+	closedChannel <- true
+	log.Printf("sent 'true' over closedChannel") // !!! we dont't see this !!! due to panic()
+	return
+}
+
+var (
+	start    Graceful = graceful{}
+	timeLeft          = 1000 * time.Millisecond
+)
+
+// Close represents mongo session closing within the context deadline
+func Close(ctx context.Context /*, session *mgo.Session*/) error {
+	closedChannel := make(chan bool)
+	defer func() {
+		log.Printf("doing Close() defer")
+		close(closedChannel)
+	}()
+
+	// Make a copy of timeLeft so that we don't modify the global var
+	closeTimeLeft := timeLeft
+	if deadline, ok := ctx.Deadline(); ok {
+		// Add some time to timeLeft so case where ctx.Done in select
+		// statement below gets called before time.After(timeLeft) gets called.
+		// This is so the context error is returned over hardcoded error.
+		closeTimeLeft = deadline.Sub(time.Now()) + (10 * time.Millisecond)
+	}
+
+	go func() {
+		start.shutdown(ctx /*, session,*/, closedChannel)
+		log.Printf("returned from shutdown")
+		return
+	}()
+
+	log.Printf("waiting on select ...")
+	select {
+	case <-time.After(closeTimeLeft):
+		log.Printf("timed out")
+		return errors.New("closing mongo timed out")
+	case <-closedChannel:
+		log.Printf("received channelClosed")
+		return nil
+	case <-ctx.Done():
+		log.Printf("got ctx.Done()")
+		return ctx.Err()
+	}
+}
+
+// Demonstrate a corner case of delays that when the added "defer func()" in shutdown() is commented
+// out will cause a panic()
+// NOTE: you need to comment it out to see the problem, that is the adding of the recover() code
+//       fixes this corner case.
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	timeLeft = 800 * time.Millisecond
+	err := Close(ctx /*, session.Copy()*/)
+
+	time.Sleep(100 * time.Millisecond)
+
+	log.Printf("main(): err is: %v", err)
+
+	time.Sleep(1000 * time.Millisecond) // simulate enough further delay before application shuts down for the delay in shutdown() to expire
+}

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=


### PR DESCRIPTION
If session.Close() takes a while and there is code that executes after calling Close() that also takes a while, the right combination of delays will result in a panic in shutdown() when it writes to the closedChannel.
I have created a demo in new folder "close_corner_case_problem" to show the problem. Read and follow the comments before main() in demo_channel_closed.go

Kind Regards,

Rhys
