### PR TITLE
add a filter while retrieving collection names to fix default empty response

### DIFF
--- a/v2/pkg/mongodb/connection.go
+++ b/v2/pkg/mongodb/connection.go
@@ -86,7 +86,7 @@ func (ms *MongoConnection) ListCollectionsFor(ctx context.Context, database stri
 	collectionNames, err := ms.
 		client.
 		Database(database).
-		ListCollectionNames(ctx, bson.D{{}})
+		ListCollectionNames(ctx, bson.D{{"name",  bson.D{{"$ne", ""}}}})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What

The mongo driver on list collection API call adds in cursor batchSize 0 as default.
This is resulting in empty collection response and authorisation failure response.
To fix this we are adding a filter while retrieving collection names to fix default empty response. 

### How to review

check the code changes

### Who can review

anyone 
