### PR TITLE
Improve health check

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -113,7 +113,7 @@ func (c *CheckMongoClient) Checker(ctx context.Context, state *healthcheck.Check
 	}
 	msg := healthyMessage
 
-	if c.databaseCollection != nil {
+	if c.databaseCollection != nil && len(c.databaseCollection) > 0 {
 		err = c.checkCollections(ctx)
 		if err != nil {
 			log.Error(ctx, "Error checking collections in mongo", err)

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -17,75 +17,98 @@ func TestClient_GetOutput(t *testing.T) {
 
 	ctx := context.Background()
 
-	Convey("Given a CheckMongoClient without collections", t, func() {
-		c := NewClient(nil)
+	Convey("Given a CheckMongoClient", t, func() {
 		// CheckState for test validation
 		checkState := healthcheck.NewCheckState("test-mongodb")
+		Convey("Without collections", func() {
+			c := NewClient(nil)
 
-		Convey("When that health endpoint returns 'Success'", func() {
-			c.healthcheck = healthSuccess
-			Convey("Then Checker updates the CheckState to an OK status", func() {
-				c.Checker(ctx, checkState)
-				So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
-				So(checkState.Message(), ShouldEqual, "mongodb is OK")
-				So(checkState.StatusCode(), ShouldEqual, 0)
-			})
-		})
-
-		Convey("When that health endpoint returns 'Failure'", func() {
-			c.healthcheck = healthFailure
-			Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
-				c.Checker(ctx, checkState)
-				So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
-				So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
-				So(checkState.StatusCode(), ShouldEqual, 0)
-			})
-		})
-	})
-
-	Convey("Given a CheckMongoClient with collections", t, func() {
-		collections := map[Database][]Collection{"db": {"col1", "col2"}}
-		c := NewClientWithCollections(nil, collections)
-
-		// CheckState for test validation
-		checkState := healthcheck.NewCheckState("test-mongodb")
-
-		Convey("When that health endpoint is successful", func() {
-			c.healthcheck = healthSuccess
-
-			Convey("And the collections exist", func() {
-				c.checkCollections = func(context.Context) error {
-					return nil
-				}
+			Convey("When the health endpoint is successful", func() {
+				c.healthcheck = healthSuccess
 				Convey("Then Checker updates the CheckState to an OK status", func() {
 					c.Checker(ctx, checkState)
 					So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
-					So(checkState.Message(), ShouldEqual, "mongodb is OK and all expected collections exist")
+					So(checkState.Message(), ShouldEqual, "mongodb is OK")
 					So(checkState.StatusCode(), ShouldEqual, 0)
 				})
 			})
 
-			Convey("And the collections do not exist", func() {
-				errCollectionsDoNotExist := errors.New("can't find collection")
-				c.checkCollections = func(context.Context) error {
-					return errCollectionsDoNotExist
-				}
+			Convey("When the health endpoint returns an error", func() {
+				c.healthcheck = healthFailure
 				Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
 					c.Checker(ctx, checkState)
 					So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
-					So(checkState.Message(), ShouldEqual, errCollectionsDoNotExist.Error())
+					So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
 					So(checkState.StatusCode(), ShouldEqual, 0)
 				})
 			})
 		})
 
-		Convey("When that health endpoint returns an error", func() {
-			c.healthcheck = healthFailure
-			Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
-				c.Checker(ctx, checkState)
-				So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
-				So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
-				So(checkState.StatusCode(), ShouldEqual, 0)
+		Convey("With an empty collections map", func() {
+			c := NewClientWithCollections(nil, nil)
+
+			Convey("When the health endpoint is successful", func() {
+				c.healthcheck = healthSuccess
+				Convey("Then Checker updates the CheckState to an OK status", func() {
+					c.Checker(ctx, checkState)
+					So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
+					So(checkState.Message(), ShouldEqual, "mongodb is OK")
+					So(checkState.StatusCode(), ShouldEqual, 0)
+				})
+			})
+
+			Convey("When the health endpoint returns an error", func() {
+				c.healthcheck = healthFailure
+				Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
+					c.Checker(ctx, checkState)
+					So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
+					So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
+					So(checkState.StatusCode(), ShouldEqual, 0)
+				})
+			})
+		})
+
+		Convey("With collections", func() {
+			collections := map[Database][]Collection{"db": {"col1", "col2"}}
+			c := NewClientWithCollections(nil, collections)
+
+			Convey("When the health endpoint is successful", func() {
+				c.healthcheck = healthSuccess
+
+				Convey("And the collections exist", func() {
+					c.checkCollections = func(context.Context) error {
+						return nil
+					}
+					Convey("Then Checker updates the CheckState to an OK status", func() {
+						c.Checker(ctx, checkState)
+						So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
+						So(checkState.Message(), ShouldEqual, "mongodb is OK and all expected collections exist")
+						So(checkState.StatusCode(), ShouldEqual, 0)
+					})
+				})
+
+				Convey("And the collections do not exist", func() {
+					errCollectionsDoNotExist := errors.New("can't find collection")
+					c.checkCollections = func(context.Context) error {
+						return errCollectionsDoNotExist
+					}
+					Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
+						c.Checker(ctx, checkState)
+						So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
+						So(checkState.Message(), ShouldEqual, errCollectionsDoNotExist.Error())
+						So(checkState.StatusCode(), ShouldEqual, 0)
+					})
+				})
+			})
+
+			Convey("When the health endpoint returns an error", func() {
+				c.healthcheck = healthFailure
+				Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
+					c.Checker(ctx, checkState)
+					So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
+					So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
+					So(checkState.StatusCode(), ShouldEqual, 0)
+				})
 			})
 		})
 	})

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -11,48 +11,86 @@ import (
 )
 
 var (
-	errUnableToConnect = errors.New("unable to connect with MongoDB")
+	errUnableToConnect       = errors.New("failed to connect")
+	errCollectionsDoNotExist = errors.New("can't find collection")
 )
 
 func TestClient_GetOutput(t *testing.T) {
 
 	ctx := context.Background()
 
-	Convey("Given that health endpoint returns 'Success'", t, func() {
-
-		// MongoClient with success healthcheck
+	Convey("Given a CheckMongoClient without collections", t, func() {
 		c := &health.CheckMongoClient{
-			Client:      *health.NewClient(nil),
-			Healthcheck: healthSuccess,
+			Client: *health.NewClient(nil),
 		}
-
 		// CheckState for test validation
 		checkState := healthcheck.NewCheckState(health.ServiceName)
 
-		Convey("Checker updates the CheckState to an OK status", func() {
-			c.Checker(ctx, checkState)
-			So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
-			So(checkState.Message(), ShouldEqual, health.HealthyMessage)
-			So(checkState.StatusCode(), ShouldEqual, 0)
+		Convey("When that health endpoint returns 'Success'", func() {
+			c.Healthcheck = healthSuccess
+			Convey("Then Checker updates the CheckState to an OK status", func() {
+				c.Checker(ctx, checkState)
+				So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
+				So(checkState.Message(), ShouldEqual, "mongodb is OK")
+				So(checkState.StatusCode(), ShouldEqual, 0)
+			})
+		})
+
+		Convey("When that health endpoint returns 'Failure'", func() {
+			c.Healthcheck = healthFailure
+			Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
+				c.Checker(ctx, checkState)
+				So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
+				So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
+				So(checkState.StatusCode(), ShouldEqual, 0)
+			})
 		})
 	})
 
-	Convey("Given that health endpoint returns 'Failure'", t, func() {
-
-		// MongoClient with failure healthcheck
+	Convey("Given a CheckMongoClient with collections", t, func() {
+		collections := map[health.Database][]health.Collection{"db": {"col1", "col2"}}
 		c := &health.CheckMongoClient{
-			Client:      *health.NewClient(nil),
-			Healthcheck: healthFailure,
+			Client: *health.NewClientWithCollections(nil, collections),
 		}
-
 		// CheckState for test validation
 		checkState := healthcheck.NewCheckState(health.ServiceName)
 
-		Convey("Checker updates the CheckState to a CRITICAL status", func() {
-			c.Checker(ctx, checkState)
-			So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
-			So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
-			So(checkState.StatusCode(), ShouldEqual, 0)
+		Convey("When that health endpoint returns 'Success'", func() {
+			c.Healthcheck = healthSuccess
+
+			Convey("And the collections exist", func() {
+				c.CheckCollections = func(context.Context) error {
+					return nil
+				}
+				Convey("Then Checker updates the CheckState to an OK status", func() {
+					c.Checker(ctx, checkState)
+					So(checkState.Status(), ShouldEqual, healthcheck.StatusOK)
+					So(checkState.Message(), ShouldEqual, "mongodb is OK and all expected collections exist")
+					So(checkState.StatusCode(), ShouldEqual, 0)
+				})
+			})
+
+			Convey("And the collections do not exist", func() {
+				c.CheckCollections = func(context.Context) error {
+					return errCollectionsDoNotExist
+				}
+				Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
+					c.Checker(ctx, checkState)
+					So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
+					So(checkState.Message(), ShouldEqual, errCollectionsDoNotExist.Error())
+					So(checkState.StatusCode(), ShouldEqual, 0)
+				})
+			})
+		})
+
+		Convey("When that health endpoint returns 'Failure'", func() {
+			c.Healthcheck = healthFailure
+			Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
+				c.Checker(ctx, checkState)
+				So(checkState.Status(), ShouldEqual, healthcheck.StatusCritical)
+				So(checkState.Message(), ShouldEqual, errUnableToConnect.Error())
+				So(checkState.StatusCode(), ShouldEqual, 0)
+			})
 		})
 	})
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -24,7 +24,7 @@ func TestClient_GetOutput(t *testing.T) {
 			Client: *health.NewClient(nil),
 		}
 		// CheckState for test validation
-		checkState := healthcheck.NewCheckState(health.ServiceName)
+		checkState := healthcheck.NewCheckState("test-mongodb")
 
 		Convey("When that health endpoint returns 'Success'", func() {
 			c.Healthcheck = healthSuccess
@@ -53,9 +53,9 @@ func TestClient_GetOutput(t *testing.T) {
 			Client: *health.NewClientWithCollections(nil, collections),
 		}
 		// CheckState for test validation
-		checkState := healthcheck.NewCheckState(health.ServiceName)
+		checkState := healthcheck.NewCheckState("test-mongodb")
 
-		Convey("When that health endpoint returns 'Success'", func() {
+		Convey("When that health endpoint is successful", func() {
 			c.Healthcheck = healthSuccess
 
 			Convey("And the collections exist", func() {
@@ -83,7 +83,7 @@ func TestClient_GetOutput(t *testing.T) {
 			})
 		})
 
-		Convey("When that health endpoint returns 'Failure'", func() {
+		Convey("When that health endpoint returns an error", func() {
 			c.Healthcheck = healthFailure
 			Convey("Then Checker updates the CheckState to a CRITICAL status", func() {
 				c.Checker(ctx, checkState)
@@ -96,11 +96,11 @@ func TestClient_GetOutput(t *testing.T) {
 }
 
 var (
-	healthSuccess = func(context.Context) (string, error) {
-		return "Success", nil
+	healthSuccess = func(context.Context) error {
+		return nil
 	}
 
-	healthFailure = func(context.Context) (string, error) {
-		return "Failure", errUnableToConnect
+	healthFailure = func(context.Context) error {
+		return errUnableToConnect
 	}
 )


### PR DESCRIPTION
### What

Split the ping to mongodb and checking the existence of the collections so that we don't return a misleading message when no collections are to be checked. Instead of always returning `mongodb is OK and all expected collections exist`, it will now return the following messages:
- `mongodb is OK` (when there is no collections to check)
- `mongodb is OK and all expected collections exist`

Reduce the exported members and simplify the usage of the checker. Now a single call to `NewClient` or `NewClientWithCollections` is enough and it returns a `CheckMongoClient` to call the `Checker` function. There is no longer a need to create 2 different objects by clients of this library.

Current usage:
```
client := dpMongoHealth.NewClientWithCollections(mongoConnection, databaseCollectionBuilder)
healthClient = &dpMongoHealth.CheckMongoClient{
    Client:      *client,
    Healthcheck: client.Healthcheck,
}
...
healthClient.Checker(ctx, state)
```

New usage:
```
healthClient = dpMongoHealth.NewClientWithCollections(mongoConnection, databaseCollectionBuilder)
...
healthClient.Checker(ctx, state)
```

### How to review

Check the code and tests

### Who can review

Anyone
