### PR TITLE
Validate cluster endpoint

### DIFF
--- a/mongodb/driver.go
+++ b/mongodb/driver.go
@@ -101,7 +101,10 @@ func (m *MongoConnectionConfig) GetConnectionURI() (string, error) {
 	var connectionString string
 	endpoint := m.ClusterEndpoint
 
-	matches, _ := regexp.MatchString(endpointRegex, endpoint)
+	matches, err := regexp.MatchString(endpointRegex, endpoint)
+	if err != nil {
+		return "", err
+	}
 	if !matches {
 		return "", fmt.Errorf("Invalid mongodb address: %s", endpoint)
 	}


### PR DESCRIPTION
### What

Validate the `ClusterEndpoint` config value and accept mongodb connection strings.
It currently expects `host:port` but some services might be sending `mongodb://host:port` which we will now accept. 

### How to review

Check changes and unit tests

### Who can review

Anyone but me
