### PR TITLE
Add ReplaceOne function

### DIFF
--- a/mongodb/collection.go
+++ b/mongodb/collection.go
@@ -244,12 +244,12 @@ func (c *Collection) updateRecord(ctx context.Context, selector interface{}, upd
 	return nil, wrapMongoError(err)
 }
 
-// Replace replaces a single document located by the provided selector
+// ReplaceOne replaces a single document located by the provided selector
 // The selector must be a document containing query operators and cannot be nil.
 // The newDocument cannot be nil or empty.
 // If the selector does not match any documents, the operation will succeed and a CollectionUpdateResult with a MatchedCount of 0 will be returned.
 // If the selector matches multiple documents, one will be selected from the matched set, replaced and a CollectionUpdateResult with a MatchedCount of 1 will be returned.
-func (c *Collection) Replace(ctx context.Context, selector interface{}, newDocument interface{}) (*CollectionUpdateResult, error) {
+func (c *Collection) ReplaceOne(ctx context.Context, selector interface{}, newDocument interface{}) (*CollectionUpdateResult, error) {
 	updateResult, err := c.collection.ReplaceOne(ctx, selector, newDocument)
 	if err == nil {
 		return &CollectionUpdateResult{

--- a/mongodb/collection.go
+++ b/mongodb/collection.go
@@ -244,6 +244,23 @@ func (c *Collection) updateRecord(ctx context.Context, selector interface{}, upd
 	return nil, wrapMongoError(err)
 }
 
+// Replace replaces a single document located by the provided selector
+// The selector must be a document containing query operators and cannot be nil.
+// The newDocument cannot be nil or empty.
+// If the selector does not match any documents, the operation will succeed and a CollectionUpdateResult with a MatchedCount of 0 will be returned.
+// If the selector matches multiple documents, one will be selected from the matched set, replaced and a CollectionUpdateResult with a MatchedCount of 1 will be returned.
+func (c *Collection) Replace(ctx context.Context, selector interface{}, newDocument interface{}) (*CollectionUpdateResult, error) {
+	updateResult, err := c.collection.ReplaceOne(ctx, selector, newDocument)
+	if err == nil {
+		return &CollectionUpdateResult{
+			MatchedCount:  int(updateResult.MatchedCount),
+			ModifiedCount: int(updateResult.ModifiedCount),
+		}, nil
+	}
+
+	return nil, wrapMongoError(err)
+}
+
 // Delete deletes a single document based on the provided selector
 // Deprecated: Use DeleteOne instead
 func (c *Collection) Delete(ctx context.Context, selector interface{}) (*CollectionDeleteResult, error) {

--- a/mongodb/collection_test.go
+++ b/mongodb/collection_test.go
@@ -506,6 +506,39 @@ func TestCollectionSuite(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(res, ShouldResemble, []TestModel{{ID: 1, State: "first"}, {ID: 2, State: "first"}})
 				})
+
+				Convey("Replace should update the identified object as expected", func() {
+					newDoc := TestModel{
+						ID:     2,
+						State:  "replaced-state",
+						NewKey: 22,
+					}
+					selector := bson.M{"_id": 2}
+
+					updateResult, err := conn.Collection(collection).Replace(context.Background(), selector, newDoc)
+					So(err, ShouldBeNil)
+					So(updateResult.MatchedCount, ShouldEqual, 1)
+					So(updateResult.ModifiedCount, ShouldEqual, 1)
+
+					res := TestModel{}
+					err = queryMongo(conn, collection, selector, &res)
+					So(err, ShouldBeNil)
+					So(res, ShouldResemble, newDoc)
+				})
+
+				Convey("Replace updates no documents if none match", func() {
+					newDoc := TestModel{
+						State:  "replaced-state",
+						NewKey: 22,
+					}
+					selector := bson.M{"_id": 171}
+					Convey("Replace should succeed but return 0 matches", func() {
+						updateResult, err := conn.Collection(collection).Replace(context.Background(), selector, newDoc)
+						So(err, ShouldBeNil)
+						So(updateResult.MatchedCount, ShouldEqual, 0)
+						So(updateResult.ModifiedCount, ShouldEqual, 0)
+					})
+				})
 			})
 
 			Convey("setup with data for testing Delete functionality", func() {

--- a/mongodb/collection_test.go
+++ b/mongodb/collection_test.go
@@ -507,7 +507,7 @@ func TestCollectionSuite(t *testing.T) {
 					So(res, ShouldResemble, []TestModel{{ID: 1, State: "first"}, {ID: 2, State: "first"}})
 				})
 
-				Convey("Replace should update the identified object as expected", func() {
+				Convey("ReplaceOne should update the identified object as expected", func() {
 					newDoc := TestModel{
 						ID:     2,
 						State:  "replaced-state",
@@ -515,7 +515,7 @@ func TestCollectionSuite(t *testing.T) {
 					}
 					selector := bson.M{"_id": 2}
 
-					updateResult, err := conn.Collection(collection).Replace(context.Background(), selector, newDoc)
+					updateResult, err := conn.Collection(collection).ReplaceOne(context.Background(), selector, newDoc)
 					So(err, ShouldBeNil)
 					So(updateResult.MatchedCount, ShouldEqual, 1)
 					So(updateResult.ModifiedCount, ShouldEqual, 1)
@@ -526,18 +526,17 @@ func TestCollectionSuite(t *testing.T) {
 					So(res, ShouldResemble, newDoc)
 				})
 
-				Convey("Replace updates no documents if none match", func() {
+				Convey("ReplaceOne updates no documents if none match", func() {
 					newDoc := TestModel{
 						State:  "replaced-state",
 						NewKey: 22,
 					}
 					selector := bson.M{"_id": 171}
-					Convey("Replace should succeed but return 0 matches", func() {
-						updateResult, err := conn.Collection(collection).Replace(context.Background(), selector, newDoc)
-						So(err, ShouldBeNil)
-						So(updateResult.MatchedCount, ShouldEqual, 0)
-						So(updateResult.ModifiedCount, ShouldEqual, 0)
-					})
+
+					updateResult, err := conn.Collection(collection).ReplaceOne(context.Background(), selector, newDoc)
+					So(err, ShouldBeNil)
+					So(updateResult.MatchedCount, ShouldEqual, 0)
+					So(updateResult.ModifiedCount, ShouldEqual, 0)
 				})
 			})
 

--- a/mongodb/must.go
+++ b/mongodb/must.go
@@ -63,13 +63,13 @@ func (m *Must) UpdateMany(ctx context.Context, selector interface{}, update inte
 	return result, nil
 }
 
-// Replace modifies a single document located by the provided selector.
+// ReplaceOne modifies a single document located by the provided selector.
 // The selector must be a document containing query operators and cannot be nil.
 // The newDocument cannot be nil or empty.
 // If the selector does not match any documents, an ErrNoDocumentFound is returned
 // If the selector matches multiple documents, one will be selected from the matched set, updated and a CollectionUpdateResult with a MatchedCount of 1 will be returned.
-func (m *Must) Replace(ctx context.Context, selector interface{}, newDocument interface{}) (*CollectionUpdateResult, error) {
-	result, err := m.collection.Replace(ctx, selector, newDocument)
+func (m *Must) ReplaceOne(ctx context.Context, selector interface{}, newDocument interface{}) (*CollectionUpdateResult, error) {
+	result, err := m.collection.ReplaceOne(ctx, selector, newDocument)
 	if err != nil {
 		return nil, err
 	}

--- a/mongodb/must.go
+++ b/mongodb/must.go
@@ -63,6 +63,24 @@ func (m *Must) UpdateMany(ctx context.Context, selector interface{}, update inte
 	return result, nil
 }
 
+// Replace modifies a single document located by the provided selector.
+// The selector must be a document containing query operators and cannot be nil.
+// The newDocument cannot be nil or empty.
+// If the selector does not match any documents, an ErrNoDocumentFound is returned
+// If the selector matches multiple documents, one will be selected from the matched set, updated and a CollectionUpdateResult with a MatchedCount of 1 will be returned.
+func (m *Must) Replace(ctx context.Context, selector interface{}, newDocument interface{}) (*CollectionUpdateResult, error) {
+	result, err := m.collection.Replace(ctx, selector, newDocument)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.MatchedCount == 0 {
+		return nil, ErrNoDocumentFound
+	}
+
+	return result, nil
+}
+
 // DeleteById deletes a single document located by the provided id selector. If no document is not found
 // an ErrNoDocumentFound error is returned
 // Deprecated: Use DeleteOne

--- a/testcomponent/features/collection.feature
+++ b/testcomponent/features/collection.feature
@@ -7,12 +7,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -38,12 +40,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "UpsertName1",
-                    "age": "UpsertAge1"
+                    "age": "UpsertAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -69,12 +73,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -105,12 +111,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "UpsertByIdName1",
-                    "age": "UpsertByIdAge1"
+                    "age": "UpsertByIdAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -136,12 +144,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -172,12 +182,14 @@ Feature: Collection records
                     {
                         "id": 1,
                         "name": "TestName1",
-                        "age": "TestAge1"
+                        "age": "TestAge1",
+                        "height": 160
                     },
                     {
                         "id": 2,
                         "name": "TestName2",
-                        "age": "TestAge2"
+                        "age": "TestAge2",
+                        "height": 170
                     },
                     {
                         "id": 3,
@@ -185,7 +197,7 @@ Feature: Collection records
                         "age": "UpdateAge3"
                     }
                 ]
-                """
+            """
 
   Scenario:
     When I update this record with id 4
@@ -203,12 +215,14 @@ Feature: Collection records
                     {
                         "id": 1,
                         "name": "TestName1",
-                        "age": "TestAge1"
+                        "age": "TestAge1",
+                        "height": 160
                     },
                     {
                         "id": 2,
                         "name": "TestName2",
-                        "age": "TestAge2"
+                        "age": "TestAge2",
+                        "height": 170
                     },
                     {
                         "id": 3,
@@ -216,7 +230,7 @@ Feature: Collection records
                         "age": "TestAge3"
                     }
                 ]
-                """
+            """
 
   Scenario:
     When I updateById this record with id 3
@@ -234,12 +248,14 @@ Feature: Collection records
                     {
                         "id": 1,
                         "name": "TestName1",
-                        "age": "TestAge1"
+                        "age": "TestAge1",
+                        "height": 160
                     },
                     {
                         "id": 2,
                         "name": "TestName2",
-                        "age": "TestAge2"
+                        "age": "TestAge2",
+                        "height": 170
                     },
                     {
                         "id": 3,
@@ -247,7 +263,7 @@ Feature: Collection records
                         "age": "UpdateWithIdAge3"
                     }
                 ]
-                """
+            """
 
   Scenario:
     When I updateById this record with id 4
@@ -265,12 +281,14 @@ Feature: Collection records
                     {
                         "id": 1,
                         "name": "TestName1",
-                        "age": "TestAge1"
+                        "age": "TestAge1",
+                        "height": 160
                     },
                     {
                         "id": 2,
                         "name": "TestName2",
-                        "age": "TestAge2"
+                        "age": "TestAge2",
+                        "height": 170
                     },
                     {
                         "id": 3,
@@ -278,7 +296,42 @@ Feature: Collection records
                         "age": "TestAge3"
                     }
                 ]
-                """
+            """
+
+  Scenario: Replace document
+    When I replace this record with id 2
+            """
+            {
+                "name": "Replaced name",
+                "age": "Older now",
+                "height": 178
+            } 
+            """
+    Then there are 1 matched, 1 modified, 0 upserted records
+    When I filter on all records
+    Then I should find these records
+            """
+            [
+                {
+                    "id": 1,
+                    "name": "TestName1",
+                    "age": "TestAge1",
+                    "height": 160
+                },
+                {
+                    "id": 2,
+                    "name": "Replaced name",
+                    "age": "Older now",
+                    "height": 178
+                },
+                {
+                    "id": 3,
+                    "name": "Test3",
+                    "age": "TestAge3"
+                }
+            ]
+            """
+
 
   Scenario:
     Given I deleteById a record with id 2
@@ -290,7 +343,8 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 3,
@@ -310,12 +364,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -335,7 +391,8 @@ Feature: Collection records
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -355,12 +412,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,
@@ -412,12 +471,14 @@ Feature: Collection records
                 {
                     "id": 1,
                     "name": "TestName1",
-                    "age": "TestAge1"
+                    "age": "TestAge1",
+                    "height": 160
                 },
                 {
                     "id": 2,
                     "name": "TestName2",
-                    "age": "TestAge2"
+                    "age": "TestAge2",
+                    "height": 170
                 },
                 {
                     "id": 3,

--- a/testcomponent/features/must.feature
+++ b/testcomponent/features/must.feature
@@ -86,6 +86,27 @@ Feature: Must operation records
             """
     Then I should receive a ErrNoDocumentFound error
 
+  Scenario: Replace matching document
+    When I Must replace this record with id 3
+            """
+            {
+                "name": "UpdateWithIdName3",
+                "age": "UpdateWithIdAge3"
+            } 
+            """
+    Then there are 1 matched, 1 modified, 0 upserted records
+    And Must did not return an error
+
+  Scenario: Replace non matching document
+    When I Must replace this record with id 12
+            """
+            {
+                "name": "UpdateWithIdName3",
+                "age": "UpdateWithIdAge3"
+            } 
+            """
+    Then I should receive a ErrNoDocumentFound error
+
   Scenario:
     When I Must deleteById a record with id 2
     Then there are 1 deleted records

--- a/testcomponent/steps.go
+++ b/testcomponent/steps.go
@@ -17,9 +17,10 @@ import (
 )
 
 type dataModel struct {
-	Id   int `bson:"_id,omitempty" json:"id,omitempty"`
-	Name string
-	Age  string
+	Id     int `bson:"_id,omitempty" json:"id,omitempty"`
+	Name   string
+	Age    string
+	Height int
 }
 
 type find struct {
@@ -62,6 +63,7 @@ func (m *MongoV2Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I upsert this record with id (\d+)$`, m.upsertRecord)
 	ctx.Step(`^I updateById this record with id (\d+)$`, m.updateRecordById)
 	ctx.Step(`^I update this record with id (\d+)$`, m.updateRecord)
+	ctx.Step(`^I replace this record with id (\d+)$`, m.replaceRecord)
 	ctx.Step(`^I deleteById a record with id (\d+)$`, m.deleteRecordById)
 	ctx.Step(`^I delete a record with id (\d+)$`, m.deleteRecord)
 	ctx.Step(`^I delete a record with name like (\w+)$`, m.deleteRecordByName)
@@ -76,6 +78,7 @@ func (m *MongoV2Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^Must did not return an error$`, m.testMustDidNotReturnError)
 	ctx.Step(`^I Must update this record with id (\d+)$`, m.mustUpdateRecord)
 	ctx.Step(`^I Must updateById this record with id (\d+)$`, m.mustUpdateId)
+	ctx.Step(`^I Must replace this record with id (\d+)$`, m.mustReplaceRecord)
 	ctx.Step(`^I Must deleteById a record with id (\d+)$`, m.mustDeleteRecordById)
 	ctx.Step(`^I Must delete a record with id (\d+)$`, m.mustDeleteRecord)
 	ctx.Step(`^I Must delete records with name like (\w+)$`, m.mustDeleteRecordsByName)
@@ -269,51 +272,50 @@ func (m *MongoV2Component) findOneRecord(recordAsString *godog.DocString) error 
 }
 
 func (m *MongoV2Component) upsertRecordById(id int, recordAsString *godog.DocString) error {
-	record := new(dataModel)
+	idQuery := bson.D{{Key: "_id", Value: id}}
 
-	err := json.Unmarshal([]byte(recordAsString.Content), &record)
-	if err != nil {
-		return err
-	}
+	updateDoc, err := getUpdateDoc(recordAsString)
+	upsert := bson.D{{Key: "$set", Value: updateDoc}}
 
-	upsert := bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: record.Name}, {Key: "age", Value: record.Age}}}}
-
-	m.updateResult, err = m.testClient.Collection(m.collection).UpsertOne(context.Background(), bson.M{"_id": id}, upsert)
+	m.updateResult, err = m.testClient.Collection(m.collection).UpsertOne(context.Background(), idQuery, upsert)
 
 	return err
 }
 
 func (m *MongoV2Component) upsertRecord(id int, recordAsString *godog.DocString) error {
-	record := new(dataModel)
+	idQuery := bson.D{{Key: "_id", Value: id}}
 
-	err := json.Unmarshal([]byte(recordAsString.Content), &record)
-	if err != nil {
-		return err
-	}
+	updateDoc, err := getUpdateDoc(recordAsString)
+	upsert := bson.D{{Key: "$set", Value: updateDoc}}
 
-	upsert := bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: record.Name}, {Key: "age", Value: record.Age}}}}
-
-	m.updateResult, err = m.testClient.Collection(m.collection).UpsertOne(context.Background(), bson.M{"_id": id}, upsert)
+	m.updateResult, err = m.testClient.Collection(m.collection).UpsertOne(context.Background(), idQuery, upsert)
 
 	return err
 }
 
 func (m *MongoV2Component) updateRecordById(id int, recordAsString *godog.DocString) error {
-	record := new(dataModel)
+	idQuery := bson.D{{Key: "_id", Value: id}}
 
-	err := json.Unmarshal([]byte(recordAsString.Content), &record)
-	if err != nil {
-		return err
-	}
+	updateDoc, err := getUpdateDoc(recordAsString)
+	update := bson.D{{Key: "$set", Value: updateDoc}}
 
-	update := bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: record.Name}, {Key: "age", Value: record.Age}}}}
-
-	m.updateResult, err = m.testClient.Collection(m.collection).UpdateOne(context.Background(), bson.M{"_id": id}, update)
+	m.updateResult, err = m.testClient.Collection(m.collection).UpdateOne(context.Background(), idQuery, update)
 
 	return err
 }
 
 func (m *MongoV2Component) updateRecord(id int, recordAsString *godog.DocString) error {
+	idQuery := bson.D{{Key: "_id", Value: id}}
+
+	updateDoc, err := getUpdateDoc(recordAsString)
+	update := bson.D{{Key: "$set", Value: updateDoc}}
+
+	m.updateResult, err = m.testClient.Collection(m.collection).UpdateOne(context.Background(), idQuery, update)
+
+	return err
+}
+
+func (m *MongoV2Component) replaceRecord(id int, recordAsString *godog.DocString) error {
 	record := new(dataModel)
 
 	err := json.Unmarshal([]byte(recordAsString.Content), &record)
@@ -321,9 +323,7 @@ func (m *MongoV2Component) updateRecord(id int, recordAsString *godog.DocString)
 		return err
 	}
 
-	update := bson.D{{Key: "$set", Value: bson.D{{Key: "name", Value: record.Name}, {Key: "age", Value: record.Age}}}}
-
-	m.updateResult, err = m.testClient.Collection(m.collection).UpdateOne(context.Background(), bson.M{"_id": id}, update)
+	m.updateResult, err = m.testClient.Collection(m.collection).Replace(context.Background(), bson.M{"_id": id}, record)
 
 	return err
 }
@@ -475,6 +475,20 @@ func (m *MongoV2Component) mustUpdateRecord(id int, recordAsString *godog.DocStr
 	return nil
 }
 
+func (m *MongoV2Component) mustReplaceRecord(id int, recordAsString *godog.DocString) error {
+	record := new(dataModel)
+
+	err := json.Unmarshal([]byte(recordAsString.Content), &record)
+	if err != nil {
+		return err
+	}
+
+	idQuery := bson.M{"_id": id}
+	m.updateResult, m.mustErrorResult = m.testClient.Collection(m.collection).Must().Replace(context.Background(), idQuery, record)
+
+	return nil
+}
+
 func (m *MongoV2Component) testRecieveErrNoDocumentFoundError() error {
 	assert.True(&m.ErrorFeature, errors.Is(m.mustErrorResult, mongoDriver.ErrNoDocumentFound))
 
@@ -539,4 +553,29 @@ func (m *MongoV2Component) runTransaction(interference string) error {
 	}
 
 	return m.ErrorFeature.StepError()
+}
+
+// Builds the update doc based on the populated values of the record
+func getUpdateDoc(recordAsString *godog.DocString) (bson.D, error) {
+	record := new(dataModel)
+
+	err := json.Unmarshal([]byte(recordAsString.Content), &record)
+	if err != nil {
+		return nil, err
+	}
+
+	update := bson.D{}
+	if record.Name != "" {
+		update = append(update, bson.E{Key: "name", Value: record.Name})
+	}
+
+	if record.Age != "" {
+		update = append(update, bson.E{Key: "age", Value: record.Age})
+	}
+
+	if record.Height != 0 {
+		update = append(update, bson.E{Key: "height", Value: record.Height})
+	}
+
+	return update, nil
 }

--- a/testcomponent/steps.go
+++ b/testcomponent/steps.go
@@ -323,7 +323,7 @@ func (m *MongoV2Component) replaceRecord(id int, recordAsString *godog.DocString
 		return err
 	}
 
-	m.updateResult, err = m.testClient.Collection(m.collection).Replace(context.Background(), bson.M{"_id": id}, record)
+	m.updateResult, err = m.testClient.Collection(m.collection).ReplaceOne(context.Background(), bson.M{"_id": id}, record)
 
 	return err
 }
@@ -484,7 +484,7 @@ func (m *MongoV2Component) mustReplaceRecord(id int, recordAsString *godog.DocSt
 	}
 
 	idQuery := bson.M{"_id": id}
-	m.updateResult, m.mustErrorResult = m.testClient.Collection(m.collection).Must().Replace(context.Background(), idQuery, record)
+	m.updateResult, m.mustErrorResult = m.testClient.Collection(m.collection).Must().ReplaceOne(context.Background(), idQuery, record)
 
 	return nil
 }


### PR DESCRIPTION
### What

Add new `ReplaceOne` function to replace a single document, as opposed to `Update` which updates fields.
Amend existing unit tests to ensure fields not present in the update document aren't affected with an update operation wheres they are gone with a replace

### How to review

Check changes make sense, follow standards and tests coverage is sufficient

### Who can review

Anyone
