### PR TITLE
Add collation to find options

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.11-bookworm
+    tag: 1.24.13-bookworm
 
 inputs:
   - name: dp-mongodb

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.24.11-dind-24
+    tag: 1.24.13-dind-24
 
 inputs:
   - name: dp-mongodb

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.24.11-bookworm
+    tag: 1.24.13-bookworm
 
 inputs:
   - name: dp-mongodb

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.24.11-dind-24
+    tag: 1.24.13-dind-24
 
 inputs:
   - name: dp-mongodb

--- a/mongodb/options.go
+++ b/mongodb/options.go
@@ -17,6 +17,7 @@ var (
 	}
 	Projection     = func(p interface{}) FindOption { return func(f *findOptions) { f.projection = p } }
 	ReturnDocument = func(when options.ReturnDocument) FindOption { return func(f *findOptions) { f.returnDocument = when } }
+	Collation      = func(c *options.Collation) FindOption { return func(f *findOptions) { f.collation = c } }
 
 	IgnoreZeroLimit = func() FindOption { return func(f *findOptions) { f.obeyZeroLimit = false } }
 )
@@ -28,6 +29,7 @@ type findOptions struct {
 	sort           interface{}
 	projection     interface{}
 	obeyZeroLimit  bool
+	collation      *options.Collation
 }
 
 func newFindOptions(opts ...FindOption) *findOptions {
@@ -40,7 +42,7 @@ func newFindOptions(opts ...FindOption) *findOptions {
 }
 
 func (fo findOptions) asDriverFindOption() *options.FindOptions {
-	return options.Find().SetSort(fo.sort).SetSkip(fo.skip).SetLimit(fo.limit).SetProjection(fo.projection)
+	return options.Find().SetSort(fo.sort).SetSkip(fo.skip).SetLimit(fo.limit).SetProjection(fo.projection).SetCollation(fo.collation)
 }
 
 func (fo findOptions) asDriverFindOneOption() *options.FindOneOptions {

--- a/testcomponent/features/find.feature
+++ b/testcomponent/features/find.feature
@@ -175,6 +175,55 @@ Feature: Find records
             ]
             """
 
+    Scenario: Find all records sorted using collation
+        When I insert these records
+            """
+            [
+                {
+                    "id": 4,
+                    "name": "b_name_4",
+                    "age": "b_age_4"
+                },
+                {
+                    "id": 5,
+                    "name": "a_name_5",
+                    "age": "a_age_5"
+                }
+            ]
+            """
+        And I filter on all records
+        And I sort by name with collation
+        Then I should find these records
+            """
+            [
+                {
+                    "id": 5,
+                    "name": "a_name_5",
+                    "age": "a_age_5"
+                },
+                {
+                    "id": 4,
+                    "name": "b_name_4",
+                    "age": "b_age_4"
+                },
+                {
+                    "id": 1,
+                    "name": "TestName1",
+                    "age": "TestAge1"
+                },
+                {
+                    "id": 2,
+                    "name": "TestName2",
+                    "age": "TestAge2"
+                },
+                {
+                    "id": 3,
+                    "name": "TestName3",
+                    "age": "TestAge2"
+                }
+            ]
+            """
+
     Scenario: Count all records
         When I filter on all records
         Then I will count 3 records

--- a/testcomponent/steps.go
+++ b/testcomponent/steps.go
@@ -8,6 +8,7 @@ import (
 
 	componenttest "github.com/ONSdigital/dp-component-test"
 	mongoDriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/cucumber/godog"
 	"github.com/stretchr/testify/assert"
@@ -82,6 +83,7 @@ func (m *MongoV2Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I update records with name "([^"]*)" age to "([^"]*)"$`, m.iUpdateRecordsWithGroupAgeTo)
 	ctx.Step(`^the records should match$`, m.theRecordsShouldMatch)
 	ctx.Step(`^I update the record in a transaction (without|with) interference$`, m.runTransaction)
+	ctx.Step(`^I sort by name with collation$`, m.findAndSortWithCollation)
 }
 
 func newMongoV2Component(database string, collection string, rawClient mongo.Client) *MongoV2Component {
@@ -539,4 +541,10 @@ func (m *MongoV2Component) runTransaction(interference string) error {
 	}
 
 	return m.ErrorFeature.StepError()
+}
+
+func (m *MongoV2Component) findAndSortWithCollation() error {
+	m.find.options = append(m.find.options, mongoDriver.Sort(bson.D{{Key: "name", Value: 1}}), mongoDriver.Collation(&options.Collation{Locale: "en", Strength: 2}))
+
+	return nil
 }


### PR DESCRIPTION
### What

When using the find method to retrieve results sorted alphabetically, records that have an uppercase name are returned first, then lower case records. Adding the collation option allows the results to be sorted case insensitive alphabetically.

### How to review

Check the changes look correct. Run the tests.

### Who can review
Anyone
