### PR TITLE
Remove collation option

### DIFF
--- a/mongodb/collection_test.go
+++ b/mongodb/collection_test.go
@@ -676,41 +676,6 @@ func TestCollectionSuite(t *testing.T) {
 					So(res, ShouldResemble, []TestModel{{ID: 1, State: "first"}, {ID: 2, State: "second"}, {ID: 3, State: "second"}})
 				})
 			})
-
-			Convey("Setup with data for testing Collation functionality", func() {
-				testData := []TestModel{{ID: 1, State: "first"}, {ID: 2, State: "second"}, {ID: 3, State: "Third"}}
-
-				if err := setUpTestData(ctx, conn, collection, testData); err != nil {
-					t.Fatalf("failed to insert test data, skipping tests: %v", err)
-				}
-
-				Convey("check data in original state", func() {
-					res := []TestModel{}
-
-					err := queryCursor(conn, collection, bson.M{}, &res)
-					So(err, ShouldBeNil)
-					So(res, ShouldResemble, testData)
-				})
-
-				Convey("Check sort with no collation set is upper case then lower case", func() {
-					res := []TestModel{}
-
-					n, err := conn.Collection(collection).Find(context.Background(), bson.M{}, &res, mongoDriver.Sort(bson.M{"state": 1}))
-					So(err, ShouldBeNil)
-					So(n, ShouldEqual, 3)
-					So(res, ShouldResemble, []TestModel{{ID: 3, State: "Third"}, {ID: 1, State: "first"}, {ID: 2, State: "second"}})
-				})
-
-				Convey("Check sort with collation strength 2 is case insensitive", func() {
-					res := []TestModel{}
-
-					n, err := conn.Collection(collection).Find(context.Background(), bson.M{}, &res, mongoDriver.Sort(bson.M{"state": 1}), mongoDriver.Collation(&options.Collation{Locale: "en", Strength: 2}))
-					So(err, ShouldBeNil)
-					So(n, ShouldEqual, 3)
-					So(res, ShouldResemble, []TestModel{{ID: 1, State: "first"}, {ID: 2, State: "second"}, {ID: 3, State: "Third"}})
-
-				})
-			})
 		})
 	})
 }

--- a/mongodb/options.go
+++ b/mongodb/options.go
@@ -17,7 +17,6 @@ var (
 	}
 	Projection     = func(p interface{}) FindOption { return func(f *findOptions) { f.projection = p } }
 	ReturnDocument = func(when options.ReturnDocument) FindOption { return func(f *findOptions) { f.returnDocument = when } }
-	Collation      = func(c *options.Collation) FindOption { return func(f *findOptions) { f.collation = c } }
 
 	IgnoreZeroLimit = func() FindOption { return func(f *findOptions) { f.obeyZeroLimit = false } }
 )
@@ -29,7 +28,6 @@ type findOptions struct {
 	sort           interface{}
 	projection     interface{}
 	obeyZeroLimit  bool
-	collation      *options.Collation
 }
 
 func newFindOptions(opts ...FindOption) *findOptions {
@@ -42,7 +40,7 @@ func newFindOptions(opts ...FindOption) *findOptions {
 }
 
 func (fo findOptions) asDriverFindOption() *options.FindOptions {
-	return options.Find().SetSort(fo.sort).SetSkip(fo.skip).SetLimit(fo.limit).SetProjection(fo.projection).SetCollation(fo.collation)
+	return options.Find().SetSort(fo.sort).SetSkip(fo.skip).SetLimit(fo.limit).SetProjection(fo.projection)
 }
 
 func (fo findOptions) asDriverFindOneOption() *options.FindOneOptions {

--- a/testcomponent/features/find.feature
+++ b/testcomponent/features/find.feature
@@ -175,55 +175,6 @@ Feature: Find records
             ]
             """
 
-    Scenario: Find all records sorted using collation
-        When I insert these records
-            """
-            [
-                {
-                    "id": 4,
-                    "name": "b_name_4",
-                    "age": "b_age_4"
-                },
-                {
-                    "id": 5,
-                    "name": "a_name_5",
-                    "age": "a_age_5"
-                }
-            ]
-            """
-        And I filter on all records
-        And I sort by name with collation
-        Then I should find these records
-            """
-            [
-                {
-                    "id": 5,
-                    "name": "a_name_5",
-                    "age": "a_age_5"
-                },
-                {
-                    "id": 4,
-                    "name": "b_name_4",
-                    "age": "b_age_4"
-                },
-                {
-                    "id": 1,
-                    "name": "TestName1",
-                    "age": "TestAge1"
-                },
-                {
-                    "id": 2,
-                    "name": "TestName2",
-                    "age": "TestAge2"
-                },
-                {
-                    "id": 3,
-                    "name": "TestName3",
-                    "age": "TestAge2"
-                }
-            ]
-            """
-
     Scenario: Count all records
         When I filter on all records
         Then I will count 3 records

--- a/testcomponent/steps.go
+++ b/testcomponent/steps.go
@@ -8,7 +8,6 @@ import (
 
 	componenttest "github.com/ONSdigital/dp-component-test"
 	mongoDriver "github.com/ONSdigital/dp-mongodb/v3/mongodb"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/cucumber/godog"
 	"github.com/stretchr/testify/assert"
@@ -83,7 +82,6 @@ func (m *MongoV2Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I update records with name "([^"]*)" age to "([^"]*)"$`, m.iUpdateRecordsWithGroupAgeTo)
 	ctx.Step(`^the records should match$`, m.theRecordsShouldMatch)
 	ctx.Step(`^I update the record in a transaction (without|with) interference$`, m.runTransaction)
-	ctx.Step(`^I sort by name with collation$`, m.findAndSortWithCollation)
 }
 
 func newMongoV2Component(database string, collection string, rawClient mongo.Client) *MongoV2Component {
@@ -541,10 +539,4 @@ func (m *MongoV2Component) runTransaction(interference string) error {
 	}
 
 	return m.ErrorFeature.StepError()
-}
-
-func (m *MongoV2Component) findAndSortWithCollation() error {
-	m.find.options = append(m.find.options, mongoDriver.Sort(bson.D{{Key: "name", Value: 1}}), mongoDriver.Collation(&options.Collation{Locale: "en", Strength: 2}))
-
-	return nil
 }


### PR DESCRIPTION
### What
Collation was added to allow datasets to be sorted case insensitively, however the current used version of documentdb does not support this option and the dataset-api get datasets endpoint would error.
### How to review

Check the changes make sense
`make test`

### Who can review

Anyone